### PR TITLE
BRBASE-24-RV-302B-C7-Kernel-Modul-Overlay

### DIFF
--- a/arch/arm/boot/dts/overlays/brbase-i2c1-overlay.dts
+++ b/arch/arm/boot/dts/overlays/brbase-i2c1-overlay.dts
@@ -1,0 +1,46 @@
+// Device tree overlay for https://kws-computer.de/produkte-2/bridgeth/base
+// for details see ...
+
+/dts-v1/;
+/plugin/;
+
+/ {
+    compatible = "brcm,bcm2835";
+
+    fragment@0 {
+        target = <&i2c_arm>;
+        __overlay__ {
+            status = "disabled";
+        };
+    };
+
+    fragment@1 {
+        target-path = "/";
+        __overlay__ {
+            i2c1: i2c-gpio@1 {
+                #address-cells = <1>;
+                #size-cells = <0>;
+                compatible = "i2c-gpio";
+                gpios = <&gpio 2 6>, /* SDA GPIO_OPEN_DRAIN */
+                        <&gpio 3 6>; /* CLK GPIO_OPEN_DRAIN */
+                clock-frequency = <400000>;
+                status = "okay";
+            };
+        };
+    };
+
+    fragment@2 {
+        target = <&i2c1>;
+        __overlay__ {
+            #address-cells = <1>;
+            #size-cells = <0>;
+
+            rtc: rv3028@54 {
+                compatible = "microcrystal,rv3028";
+                reg = <0x52>;
+                backup-switchover-mode = <3>;
+                trickle-resistor-ohms = <3000>;
+            };
+        };
+    };
+};


### PR DESCRIPTION
	  - add of rv3028-C7 to the i2c1-overlay